### PR TITLE
docs/README.md symlink was broken

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,1 @@
-../../README.md
+../README.md


### PR DESCRIPTION
referring to 2 levels up which is not accurate after docs were rearranged