### PR TITLE
switch to DifferentialEquations.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -24,7 +24,7 @@ ProgressMeter
 Distributions
 DataStructures
 DataFrames
-ODE
+OrdinaryDiffEq
 NMF
 BlackBoxOptim
 Klara 0.8.6

--- a/examples/ode/dode.jl
+++ b/examples/ode/dode.jl
@@ -1,8 +1,9 @@
 import Base.Test
 import Mads
 md = Mads.loadmadsfile("ode.mads")
-t, y = ode23s(funcosc, initialconditions, times, points=:specified)
-ys = hcat(y...)' # vectorizing the output and transposing it with '
+prob = OrdinaryDiffEq.ODEProblem(funcosc, initialconditions, (0.0,100.0))
+sol = OrdinaryDiffEq.solve(prob,Tsit5(), saveat=times)
+ys = convert(Array,sol)
 Mads.createobservations!(md, t, ys[:,1])
 if isdir("odecheckpoints")
 	rm("odecheckpoints"; recursive=true)


### PR DESCRIPTION
This PR replaces the usage of ODE.jl with OrdinaryDiffEq.jl, the ODE solvers for DifferentialEquations.jl. The resulting code is more robust and more efficient. Also, ODE.jl is essentially being deprecated for OrdinaryDiffEq.jl and so this will have more maitanance.